### PR TITLE
function name changed: "toString" -> "toCboot"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Once you get a group `G`:
 
 1. Get bootstrap equations by `bootAll[]`. If you need human-readable format, use `format[...]`.
 
-1. *(Optionally)* You can get a Python code for [cboot](https://github.com/tohtsky/cboot) by `toString[makeSDP[eq]]`.
+1. *(Optionally)* You can get a Python code for [cboot](https://github.com/tohtsky/cboot) by `toCboot[makeSDP[eq]]`.
 
 ### Irreps
 


### PR DESCRIPTION
function name changed: "toString" -> "toCboot" (follow-up for f7448b2000a686c1ec7103c0b213020ce86606d9)